### PR TITLE
Use system_registry ~> 0.7 from Hex instead of GitHub version

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -22,8 +22,7 @@ defmodule SystemRegistry.TermStorage.Mixfile do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      #{:system_registry, "~> 0.5"}
-      {:system_registry, github: "nerves-project/system_registry", branch: "remove_term_storage"}
+      {:system_registry, "~> 0.7"}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,1 +1,3 @@
-%{"system_registry": {:git, "https://github.com/nerves-project/system_registry.git", "5449f723fd508af4ba567adb96159040e2e79fb4", [branch: "remove_term_storage"]}}
+%{
+  "system_registry": {:hex, :system_registry, "0.7.0", "cd3aaf2c15392fa60f93869dde49f536fcf60e54f3b15db737e7d4ebcac108f4", [:mix], [], "hexpm"},
+}


### PR DESCRIPTION
Version `0.7` of `system_registry` extracted the term storage, so it can be used now. It would be great to create a new release afterward, so we can get the term storage from Hex :)